### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,59 +1,11 @@
 version: 2
 updates:
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: dash
-    versions:
-    - ">= 1.17.a, < 1.18"
-  - dependency-name: ipython
-    versions:
-    - ">= 7.18.a, < 7.19"
-  - dependency-name: numpy
-    versions:
-    - "> 1.19.2, < 1.20"
-  - dependency-name: numpy
-    versions:
-    - ">= 1.20.a, < 1.21"
-  - dependency-name: pandas
-    versions:
-    - ">= 1.2.a, < 1.3"
-  - dependency-name: sentry-sdk
-    versions:
-    - "> 0.19.2, < 0.20"
-  - dependency-name: stomp-py
-    versions:
-    - ">= 7.0.a, < 7.1"
-  - dependency-name: dash
-    versions:
-    - 1.19.0
-    - 1.20.0
-  - dependency-name: dash-core-components
-    versions:
-    - 1.15.0
-    - 1.16.0
-  - dependency-name: dash-html-components
-    versions:
-    - 1.1.2
-    - 1.1.3
-  - dependency-name: stomp-py
-    versions:
-    - 6.1.1
-  - dependency-name: pylint
-    versions:
-    - 2.6.2
-  - dependency-name: docker
-    versions:
-    - 4.4.2
-  - dependency-name: plotly
-    versions:
-    - 4.14.3
-  - dependency-name: django-plotly-dash
-    versions:
-    - 1.6.0
-  - dependency-name: mock
-    versions:
-    - 4.0.3
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Add Dependabot checking for github actions

## Changes

Clear the ignore section of Dependabot - the majority of Dependencies listed are not used anymore (e.g. Dash), and the ones that are have been superseded by newer version (e.g. Docker ignore 4.4.2, but uses 5.0.3 currently)